### PR TITLE
Update Aura installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,12 @@ Follow the instructions at https://github.com/Infinisil/all-hies
 
 ### Installation on ArchLinux
 
-An [haskell-ide-engine-git](https://aur.archlinux.org/packages/haskell-ide-engine-git/) package is available on the AUR.
+An [haskell-ide-engine](https://aur.archlinux.org/packages/haskell-ide-engine/) package is available on the AUR.
 
 Using [Aura](https://github.com/aurapm/aura):
 
 ```
-# aura -A haskell-ide-engine-git
+# aura -A haskell-ide-engine
 ```
 
 


### PR DESCRIPTION
The suggested Aura package, `haskell-ide-engine-git`, has been flagged out of date and has not been updated in about a year (and did not build on my machine due to a missing `stack.yaml` file in the project repo). This commit instructs the reader to install `hadkell-ide-engine` instead, as this package seems to be maintained (and did build on my machine).